### PR TITLE
Corrected calculations in cosine_mixture and leon.

### DIFF
--- a/landscapes/single_objective.py
+++ b/landscapes/single_objective.py
@@ -575,7 +575,7 @@ def cosine_mixture(x):
     Test Problems,” Journal of Global Optimization, vol. 31, pp. 635-672, 2005.
     '''
 
-    return -0.1 * sum([cos(5*pi*v) for v in x]) - sum([v**2 for v in x])
+    return -0.1 * sum([cos(5*pi*v) for v in x]) + sum([v**2 for v in x])
 
 
 def cross_in_tray(xy):
@@ -967,7 +967,7 @@ def leon(xy):
      John Wliley & Sons, 1966.
     '''
     x, y = xy[0], xy[1]
-    return 100*(y-x**3)*2 + (1-x)**2
+    return 100*(y-x**3)**2 + (1-x)**2
 
 
 def levi_n13(xy):

--- a/landscapes/single_objective.py
+++ b/landscapes/single_objective.py
@@ -575,7 +575,7 @@ def cosine_mixture(x):
     Test Problems,” Journal of Global Optimization, vol. 31, pp. 635-672, 2005.
     '''
 
-    return -0.1 * sum([cos(5*pi*v) for v in x]) + sum([v**2 for v in x])
+    return 0.1 * sum([cos(5*pi*v) for v in x]) - sum([v**2 for v in x])
 
 
 def cross_in_tray(xy):

--- a/tests/test_single_objective.py
+++ b/tests/test_single_objective.py
@@ -157,7 +157,7 @@ class test_single_objective(unittest.TestCase):
 
     def test_cosine_mixture(self):
         for d in range(D_MIN, D_MAX, 1):
-            g_min = -0.1 * d
+            g_min = 0.1 * d
             x = [0 for i in range(0, d)]
             self.assertLess(abs(g_min - cosine_mixture(x)), 1e-6)
 


### PR DESCRIPTION
cosine mixture had a sign error in one term, see: https://al-roomi.org/benchmarks/unconstrained/n-dimensions/166-cosine-mixture-function

leon had `*` instead  of `**`, see https://al-roomi.org/benchmarks/unconstrained/2-dimensions/125-leon-s-function